### PR TITLE
Make the process function idempotent

### DIFF
--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -4,6 +4,7 @@ use actix_web::{
 };
 use tari_crypto::tari_utilities::hex::HexError;
 use thiserror::Error;
+use http::StatusCode;
 
 #[derive(Error, Debug)]
 pub enum ServerError {

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -4,7 +4,6 @@ use actix_web::{
 };
 use tari_crypto::tari_utilities::hex::HexError;
 use thiserror::Error;
-use http::StatusCode;
 
 #[derive(Error, Debug)]
 pub enum ServerError {


### PR DESCRIPTION
If a user has already been registered via the `/process` endpoint and it is called again, it will now fetch that user's details and Yats.